### PR TITLE
Patcherex2 init

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "angr",
     "pyelftools",
     "lief",
-    "keystone-engine@git+https://github.com/trail-of-forks/keystone@fix-directive-address-update2#subdirectory=bindings/python",
+    "keystone-engine@git+https://github.com/trail-of-forks/keystone@irene-main#subdirectory=bindings/python",
     "intelhex",
     "requests",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "angr",
     "pyelftools",
     "lief",
-    "keystone-engine",
+    "keystone-engine@git+https://github.com/trail-of-forks/keystone@fix-directive-address-update2#subdirectory=bindings/python",
     "intelhex",
     "requests",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "angr",
     "pyelftools",
     "lief",
-    "keystone-engine@git+https://github.com/trail-of-forks/keystone@irene-main#subdirectory=bindings/python",
+    "keystone-engine",
     "intelhex",
     "requests",
 ]

--- a/src/patcherex2/components/utils/utils.py
+++ b/src/patcherex2/components/utils/utils.py
@@ -12,7 +12,13 @@ class Utils:
         self.binary_path = binary_path
 
     def insert_trampoline_code(
-        self, addr, instrs, force_insert=False, detour_pos=-1, symbols=None, base_reg=None
+        self,
+        addr,
+        instrs,
+        force_insert=False,
+        detour_pos=-1,
+        symbols=None,
+        base_reg=None,
     ):
         logger.debug(f"Inserting trampoline code at {hex(addr)}: {instrs}")
         symbols = symbols if symbols else {}
@@ -94,9 +100,10 @@ class Utils:
             # so that the base is calculated correctly since mem_addr
             if not self.p.binary_analyzer.p.loader.main_object.pic:
                 base_addr -= self.p.binary_analyzer.load_base
-            instrs = self.p.target.emit_thunk(
-                base_reg, base_addr, is_thumb=is_thumb
-            ) + instrs
+            instrs = (
+                self.p.target.emit_thunk(base_reg, base_addr, is_thumb=is_thumb)
+                + instrs
+            )
 
         # replace addresses here
         instrs = self.rewrite_addresses(instrs, addr, mem_addr, is_thumb=is_thumb)
@@ -184,7 +191,9 @@ class Utils:
                             for line in instrs.splitlines()
                             if "POINTER_HANDLER" not in line
                         ]
-                    ), addr, is_thumb=self.p.binary_analyzer.is_thumb(addr)
+                    ),
+                    addr,
+                    is_thumb=self.p.binary_analyzer.is_thumb(addr),
                 )
             )
             + len(pointer_pat.findall(instrs)) * load_addr_insns_size
@@ -201,7 +210,11 @@ class Utils:
                 repair_if_moved = bool(match_result.group("repair_if_moved"))
                 # only rewrite goto addresses in between the start of the moved instructions
                 # to the end of the moved instructions
-                if repair_if_moved and goto_addr - addr >= 0 and goto_addr - addr <= self.p.target.JMP_SIZE:
+                if (
+                    repair_if_moved
+                    and goto_addr - addr >= 0
+                    and goto_addr - addr <= self.p.target.JMP_SIZE
+                ):
                     # TODO: setting the thumb bit using is_thumb isn't always necessarily true
                     goto_addr = mem_addr + instrs_size + (goto_addr - addr)
                 if is_thumb:

--- a/src/patcherex2/components/utils/utils.py
+++ b/src/patcherex2/components/utils/utils.py
@@ -162,7 +162,7 @@ class Utils:
 
     def rewrite_addresses(self, instrs, addr, mem_addr, is_thumb=False):
         pointer_pat = re.compile(
-            r"#POINTER_HANDLER (?P<register>[^, ]+), [^0-9]?(?P<imm>[0-9]+)"
+            r"POINTER_HANDLER (?P<register>[^, ]+), [^0-9]?(?P<imm>[0-9]+)"
         )
 
         # uses a fake address to get the approximate size of
@@ -173,7 +173,13 @@ class Utils:
         instrs_size = (
             len(
                 self.p.assembler.assemble(
-                    instrs, addr, is_thumb=self.p.binary_analyzer.is_thumb(addr)
+                    "\n".join(
+                        [
+                            line
+                            for line in instrs.splitlines()
+                            if "POINTER_HANDLER" not in line
+                        ]
+                    ), addr, is_thumb=self.p.binary_analyzer.is_thumb(addr)
                 )
             )
             + len(pointer_pat.findall(instrs)) * load_addr_insns_size
@@ -193,7 +199,7 @@ class Utils:
                     # TODO: setting the thumb bit using is_thumb isn't always necessarily true
                     goto_addr = mem_addr + instrs_size + (goto_addr - addr) | int(is_thumb)
                 new_line = self.p.target.emit_load_addr(goto_addr, reg_name=reg_name)
-                logger.debug(f"#POINTER_HANDLER -> {new_line}")
+                logger.debug(f"POINTER_HANDLER -> {new_line}")
             new_instrs.append(new_line)
         instrs = "\n".join(new_instrs)
         logger.debug(f"Replace addresses: {instrs}")

--- a/src/patcherex2/components/utils/utils.py
+++ b/src/patcherex2/components/utils/utils.py
@@ -89,8 +89,13 @@ class Utils:
         self.p.sypy_info["patcherex_added_functions"].append(hex(mem_addr))
 
         if base_reg:
+            base_addr = mem_addr
+            # if the binary is non PIE, we should subtract the base
+            # so that the base is calculated correctly since mem_addr
+            if not self.p.binary_analyzer.p.loader.main_object.pic:
+                base_addr -= self.p.binary_analyzer.load_base
             instrs = self.p.target.emit_thunk(
-                base_reg, mem_addr, is_thumb=is_thumb
+                base_reg, base_addr, is_thumb=is_thumb
             ) + instrs
 
         # replace addresses here

--- a/src/patcherex2/components/utils/utils.py
+++ b/src/patcherex2/components/utils/utils.py
@@ -167,7 +167,7 @@ class Utils:
 
     def rewrite_addresses(self, instrs, addr, mem_addr, is_thumb=False):
         pointer_pat = re.compile(
-            r"POINTER_HANDLER (?P<register>[^, ]+), [^0-9]?(?P<imm>[0-9]+)"
+            r"POINTER_HANDLER (?P<register>[^, ]+), [^0-9]?(?P<imm>[0-9]+)(, [^0-9]?(?P<repair_if_moved>[0-1]))?"
         )
 
         # uses a fake address to get the approximate size of
@@ -198,9 +198,10 @@ class Utils:
             if match_result := pointer_pat.search(line):
                 reg_name = match_result.group("register")
                 goto_addr = int(match_result.group("imm"))
+                repair_if_moved = bool(match_result.group("repair_if_moved"))
                 # only rewrite goto addresses in between the start of the moved instructions
                 # to the end of the moved instructions
-                if goto_addr - addr >= 0 and goto_addr - addr <= self.p.target.JMP_SIZE:
+                if repair_if_moved and goto_addr - addr >= 0 and goto_addr - addr <= self.p.target.JMP_SIZE:
                     # TODO: setting the thumb bit using is_thumb isn't always necessarily true
                     goto_addr = mem_addr + instrs_size + (goto_addr - addr)
                 if is_thumb:

--- a/src/patcherex2/components/utils/utils.py
+++ b/src/patcherex2/components/utils/utils.py
@@ -197,7 +197,9 @@ class Utils:
                 # to the end of the moved instructions
                 if goto_addr - addr >= 0 and goto_addr - addr <= self.p.target.JMP_SIZE:
                     # TODO: setting the thumb bit using is_thumb isn't always necessarily true
-                    goto_addr = mem_addr + instrs_size + (goto_addr - addr) | int(is_thumb)
+                    goto_addr = mem_addr + instrs_size + (goto_addr - addr)
+                if is_thumb:
+                    goto_addr = goto_addr | int(is_thumb)
                 new_line = self.p.target.emit_load_addr(goto_addr, reg_name=reg_name)
                 logger.debug(f"POINTER_HANDLER -> {new_line}")
             new_instrs.append(new_line)

--- a/src/patcherex2/components/utils/utils.py
+++ b/src/patcherex2/components/utils/utils.py
@@ -1,4 +1,5 @@
 import logging
+import re
 
 from ..allocation_managers.allocation_manager import MemoryFlag
 
@@ -11,7 +12,7 @@ class Utils:
         self.binary_path = binary_path
 
     def insert_trampoline_code(
-        self, addr, instrs, force_insert=False, detour_pos=-1, symbols=None
+        self, addr, instrs, force_insert=False, detour_pos=-1, symbols=None, base_reg=None
     ):
         logger.debug(f"Inserting trampoline code at {hex(addr)}: {instrs}")
         symbols = symbols if symbols else {}
@@ -29,31 +30,52 @@ class Utils:
             )
         else:
             moved_instrs = ""
-            moved_instrs_len = len(
-                self.p.assembler.assemble(
-                    self.get_instrs_to_be_moved(addr, ignore_unmovable=True),
-                    addr,  # TODO: we don't really need this addr, but better than 0x0 because 0x0 is too far away from the code
-                    is_thumb=self.p.binary_analyzer.is_thumb(addr),
-                )
+            moved_instrs_len = 0
+
+        load_addr_size = len(
+            self.p.assembler.assemble(
+                self.p.target.emit_load_addr(addr),
+                addr,
+                is_thumb=self.p.binary_analyzer.is_thumb(addr),
             )
-        trampoline_instrs_with_jump_back = (
-            instrs
-            + "\n"
-            + moved_instrs
-            + "\n"
-            + self.p.target.JMP_ASM.format(dst=hex(addr + moved_instrs_len))
         )
+        # calculate the expected size of the trampoline
+        # by summing the size of the compiled instructions
+        # excluding the POINTER_HANDLER, the size of the
+        # expanded POINTER_HANDLER pseudo-instruction
         trampoline_size = (
             len(
                 self.p.assembler.assemble(
-                    trampoline_instrs_with_jump_back,
+                    "\n".join(
+                        [
+                            line
+                            for line in instrs.splitlines()
+                            if "POINTER_HANDLER" not in line
+                        ]
+                    )
+                    + "\n"
+                    + moved_instrs
+                    + "\n"
+                    + self.p.target.JMP_ASM.format(dst=hex(addr + moved_instrs_len)),
                     addr,  # TODO: we don't really need this addr, but better than 0x0 because 0x0 is too far away from the code
                     symbols=symbols,
                     is_thumb=self.p.binary_analyzer.is_thumb(addr),
                 )
             )
-            + 4  # TODO: some time actual size is larger, but we need a better way to calculate it
+            + len(re.findall("POINTER_HANDLER", instrs)) * load_addr_size
         )
+        is_thumb = self.p.binary_analyzer.is_thumb(addr)
+        thunk_instrs_len = 0
+        if base_reg:
+            # emit thunk with addr instead of the trampoline address to calculate the size
+            thunk_instrs_len = len(
+                self.p.assembler.assemble(
+                    self.p.target.emit_thunk(base_reg, addr, is_thumb),
+                    addr,
+                    is_thumb=is_thumb,
+                )
+            )
+            trampoline_size += thunk_instrs_len
         if detour_pos == -1:
             trampoline_block = self.p.allocation_manager.allocate(
                 trampoline_size, align=0x4, flag=MemoryFlag.RX
@@ -65,8 +87,31 @@ class Utils:
             mem_addr = detour_pos
             file_addr = self.p.binary_analyzer.mem_addr_to_file_offset(mem_addr)
         self.p.sypy_info["patcherex_added_functions"].append(hex(mem_addr))
+
+        if base_reg:
+            thunk_instrs = self.p.target.emit_thunk(
+                base_reg, mem_addr, is_thumb=is_thumb
+            )
+            thunk_len = len(
+                self.p.assembler.assemble(thunk_instrs, addr, is_thumb=is_thumb)
+            )
+        else:
+            thunk_instrs = ""
+            thunk_len = 0
+
+        # replace addresses here
+        instrs = self.rewrite_addresses(instrs, addr, thunk_len, mem_addr)
+
+        trampoline_instrs_with_jump_back = (
+            instrs
+            + "\n"
+            + moved_instrs
+            + "\n"
+            + self.p.target.JMP_ASM.format(dst=hex(addr + moved_instrs_len))
+        )
+
         trampoline_bytes = self.p.assembler.assemble(
-            trampoline_instrs_with_jump_back,
+            (thunk_instrs + "\n" + trampoline_instrs_with_jump_back),
             mem_addr,
             symbols=symbols,
             is_thumb=self.p.binary_analyzer.is_thumb(addr),
@@ -120,3 +165,41 @@ class Utils:
             if self.p.assembler.assemble(asm, addr, is_thumb=is_thumb) != insn:
                 return False
         return True
+
+    def rewrite_addresses(self, instrs, addr, thunk_len, mem_addr):
+        pointer_pat = re.compile(
+            r"#POINTER_HANDLER (?P<register>[^, ]+), [^0-9]?(?P<imm>[0-9]+)"
+        )
+
+        # uses a fake address to get the approximate size of
+        load_addr_insns_size = len(
+            self.p.assembler.assemble(self.p.target.emit_load_addr(addr))
+        )
+
+        instrs_size = (
+            len(
+                self.p.assembler.assemble(
+                    instrs, addr, is_thumb=self.p.binary_analyzer.is_thumb(addr)
+                )
+            )
+            + len(pointer_pat.findall(instrs)) * load_addr_insns_size
+        )
+
+        # rewrite addresses
+        new_instrs = []
+        for line in instrs.splitlines():
+            line = line.strip()
+            new_line = line
+            if match_result := pointer_pat.search(line):
+                reg_name = match_result.group("register")
+                goto_addr = int(match_result.group("imm"))
+                # only rewrite goto addresses in between the start of the moved instructions
+                # to the end of the moved instructions
+                if goto_addr - addr >= 0 and goto_addr - addr <= self.p.target.JMP_SIZE:
+                    goto_addr = mem_addr + thunk_len + instrs_size + (goto_addr - addr)
+                new_line = self.p.target.emit_load_addr(goto_addr, reg_name=reg_name)
+                logger.debug(f"#POINTER_HANDLER -> {new_line}")
+            new_instrs.append(new_line)
+        instrs = "\n".join(new_instrs)
+        logger.debug(f"Replace addresses: {instrs}")
+        return instrs

--- a/src/patcherex2/components/utils/utils.py
+++ b/src/patcherex2/components/utils/utils.py
@@ -36,7 +36,13 @@ class Utils:
             )
         else:
             moved_instrs = ""
-            moved_instrs_len = 0
+            moved_instrs_len = len(
+                self.p.assembler.assemble(
+                    self.get_instrs_to_be_moved(addr, ignore_unmovable=True),
+                    addr,  # TODO: we don't really need this addr, but better than 0x0 because 0x0 is too far away from the code
+                    is_thumb=self.p.binary_analyzer.is_thumb(addr),
+                )
+            )
 
         load_addr_size = len(
             self.p.assembler.assemble(

--- a/src/patcherex2/patches/instruction_patches.py
+++ b/src/patcherex2/patches/instruction_patches.py
@@ -33,6 +33,7 @@ class InsertInstructionPatch(Patch):
         detour_pos=-1,
         symbols=None,
         is_thumb=False,
+        base_reg=None,
     ) -> None:
         self.addr = None
         self.name = None
@@ -45,6 +46,7 @@ class InsertInstructionPatch(Patch):
         self.detour_pos = detour_pos
         self.symbols = symbols if symbols else {}
         self.is_thumb = is_thumb
+        self.base_reg = base_reg
 
     def apply(self, p):
         if self.addr:
@@ -54,6 +56,7 @@ class InsertInstructionPatch(Patch):
                 force_insert=self.force_insert,
                 detour_pos=self.detour_pos,
                 symbols=self.symbols,
+                base_reg=self.base_reg
             )
         elif self.name:
             assembled_size = len(

--- a/src/patcherex2/patches/instruction_patches.py
+++ b/src/patcherex2/patches/instruction_patches.py
@@ -56,7 +56,7 @@ class InsertInstructionPatch(Patch):
                 force_insert=self.force_insert,
                 detour_pos=self.detour_pos,
                 symbols=self.symbols,
-                base_reg=self.base_reg
+                base_reg=self.base_reg,
             )
         elif self.name:
             assembled_size = len(

--- a/src/patcherex2/targets/elf_arm_linux.py
+++ b/src/patcherex2/targets/elf_arm_linux.py
@@ -65,3 +65,37 @@ class ElfArmLinux(Target):
         if utils == "default":
             return Utils(self.p, self.binary_path)
         raise NotImplementedError()
+
+    # Emits a thunk which calculates the base address
+    # by subtracting the patch insertion address from
+    # the current pc and stores it in the given register
+    @staticmethod
+    def emit_thunk(base_reg, insert_addr, is_thumb=False):
+        scratch_reg = "r4" if base_reg == "r3" else "r3"
+        # need to add 4/8 here since pc
+        # points to the next instruction
+        thunk_loc = insert_addr + (4 if is_thumb else 8)
+        thunk_l = 0xFFFF & thunk_loc
+        thunk_h = 0xFFFF & (thunk_loc >> 16)
+        thunk_instrs = f"""
+        mov {base_reg}, pc
+        push {{{scratch_reg}}}
+        movw {scratch_reg}, #{thunk_l}
+        movt {scratch_reg}, #{thunk_h}
+        sub {base_reg}, {scratch_reg}
+        pop {{{scratch_reg}}}
+        """
+        return thunk_instrs
+
+    @staticmethod
+    def emit_load_addr(addr, reg_name=None):
+        # place holder register to get size
+        if reg_name is None:
+            reg_name = "r2"
+        addr_l = 0xFFFF & addr
+        addr_h = 0xFFFF & (addr >> 16)
+        load_instrs = f"""
+        movw {reg_name}, #{addr_l}
+        movt {reg_name}, #{addr_h}
+        """
+        return load_instrs

--- a/src/patcherex2/targets/elf_ppc_linux.py
+++ b/src/patcherex2/targets/elf_ppc_linux.py
@@ -74,3 +74,36 @@ class ElfPpcLinux(Target):
         if utils == "default":
             return Utils(self.p, self.binary_path)
         raise NotImplementedError()
+
+    # Emits a thunk which calculates the base address
+    # by subtracting the patch insertion address from
+    # the current pc and stores it in the given register
+    @staticmethod
+    def emit_thunk(base_reg, insert_addr, is_thumb=False):
+        assert "%r" in base_reg
+        scratch_reg1 = "%r4" if base_reg == "%r3" else "%r3"
+        scratch_reg2 = "%r12" if base_reg == "%r11" else "%r11"
+
+        # add 12 since base_reg will contain
+        # the addr + 12
+        thunk_loc = insert_addr + 12
+        thunk_l = 0xFFFF & thunk_loc
+        thunk_h = 0xFFFF & (thunk_loc >> 16)
+        thunk_instrs = f"""
+        stwu %r1, -8(%r1)
+        stw {scratch_reg2}, 4(%r1)
+        stw {scratch_reg1}, 0(%r1)
+        mflr {scratch_reg2}
+        bl lb
+        lb:
+        mflr {base_reg}
+        lis {scratch_reg1}, {thunk_h}
+        ori {scratch_reg1}, {scratch_reg1}, {thunk_l}
+        sub {base_reg}, {base_reg}, {scratch_reg1}
+        mtlr {scratch_reg2}
+        lwz {scratch_reg1}, 0(%r1)
+        lwz {scratch_reg2}, 4(%r1)
+        addi %r1, %r1, 8
+        """
+
+        return thunk_instrs

--- a/src/patcherex2/targets/elf_ppc_linux.py
+++ b/src/patcherex2/targets/elf_ppc_linux.py
@@ -80,13 +80,12 @@ class ElfPpcLinux(Target):
     # the current pc and stores it in the given register
     @staticmethod
     def emit_thunk(base_reg, insert_addr, is_thumb=False):
-        assert "%r" in base_reg
         scratch_reg1 = "%r4" if base_reg == "%r3" else "%r3"
         scratch_reg2 = "%r12" if base_reg == "%r11" else "%r11"
 
-        # add 12 since base_reg will contain
-        # the addr + 12
-        thunk_loc = insert_addr + 12
+        # add 20 since base_reg will contain
+        # the addr + 20
+        thunk_loc = insert_addr + 20
         thunk_l = 0xFFFF & thunk_loc
         thunk_h = 0xFFFF & (thunk_loc >> 16)
         thunk_instrs = f"""
@@ -107,3 +106,15 @@ class ElfPpcLinux(Target):
         """
 
         return thunk_instrs
+
+    @staticmethod
+    def emit_load_addr(addr, reg_name=None):
+        if reg_name is None:
+            reg_name = "%r1"
+        addr_l = 0xFFFF & addr
+        addr_h = 0xFFFF & (addr >> 16)
+        load_instrs = f"""
+        lis {reg_name}, {addr_h}
+        ori {reg_name}, {reg_name}, {addr_l}
+        """
+        return load_instrs


### PR DESCRIPTION
 * Supports emitting thunks for our patch compiler
 * Supports rewriting addresses for our patch compiler
 * Update dependency to our keystone fork which fixes a bug with data directives and relative jumps