### PR TITLE
Stop reporting ARM for addresses whose instruction set is unknown

### DIFF
--- a/src/patcherex2/components/binary_analyzers/angr.py
+++ b/src/patcherex2/components/binary_analyzers/angr.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import bisect
 import logging
 import traceback
 
@@ -20,6 +21,7 @@ class Angr(BinaryAnalyzer):
         self._p = None
         self._cfg = None
         self._load_base = None
+        self._mapping_symbols = None
 
     @property
     def load_base(self) -> int:
@@ -208,16 +210,102 @@ class Angr(BinaryAnalyzer):
         else:
             raise TypeError(f"Invalid type for name_or_addr: {type(name_or_addr)}")
 
-    def is_thumb(self, addr: int) -> bool:
+    @property
+    def _arm_mapping_symbols(self) -> tuple[list[int], list[str]]:
+        """
+        ARM ELF ``$a``/``$t``/``$d`` mapping symbols as parallel sorted lists of
+        addresses and kinds.
+
+        Each symbol marks the *start* of a region that runs until the next one
+        (they carry no size). They are present even where CFG recovery is
+        partial, which is what makes them useful as a fallback, but they are not
+        always complete -- see :meth:`thumb_mode` for why they do not override
+        the CFG.
+
+        Addresses are returned separately because bisect needs a bare key list.
+        """
+        if self._mapping_symbols is None:
+            symbols = sorted(
+                (sym.rebased_addr, sym.name)
+                for sym in self.p.loader.main_object.symbols
+                if sym.name in ("$a", "$t", "$d")
+            )
+            self._mapping_symbols = (
+                [sym_addr for sym_addr, _ in symbols],
+                [kind for _, kind in symbols],
+            )
+            logger.debug(f"Found {len(symbols)} ARM mapping symbols")
+        return self._mapping_symbols
+
+    def _thumb_from_mapping_symbols(self, addr: int) -> bool | None:
+        """
+        Instruction set at ``addr`` per the ELF mapping symbols, or None if they
+        do not cover it. ``addr`` is a denormalized (loaded) address.
+
+        A ``$d`` region is data, not code, so no instruction set applies and this
+        reports None rather than guessing.
+        """
+        addrs, kinds = self._arm_mapping_symbols
+        idx = bisect.bisect_right(addrs, addr) - 1
+        if idx < 0:
+            return None
+        if kinds[idx] == "$t":
+            return True
+        if kinds[idx] == "$a":
+            return False
+        return None
+
+    def thumb_mode(self, addr: int) -> bool | None:
+        """
+        Whether ``addr`` is Thumb, or None when it genuinely cannot be determined.
+
+        Unlike :meth:`is_thumb` this does not fall back to a guess, so a caller
+        that is able to refuse an address can tell "definitely ARM" apart from
+        "no idea".
+
+        The CFG is consulted first: where recovery succeeded it decoded actual
+        instructions, which is stronger evidence than a mapping symbol. Mapping
+        symbols are used only where the CFG has nothing, which is the case the
+        old fallback answered with a bare "ARM".
+
+        Note that mapping symbols alone are *not* reliable enough to override the
+        CFG: toolchains omit them. In ``printf_pie`` the ``$t`` at ``0x500``
+        covers Thumb ``frame_dummy`` but no ``$a`` marks ARM ``main`` at
+        ``0x504``, so the symbols imply Thumb for an ARM function.
+
+        :param addr: The address to query, in the same (normalized) convention
+            the other methods here take.
+        :return: True for Thumb, False for ARM, None if undeterminable.
+        """
         if not isinstance(self.p.arch, ArchARM):
             return False
-        addr = self.denormalize_addr(addr)
+        loaded_addr = self.denormalize_addr(addr)
 
-        for node in self.cfg.model.nodes():
-            if addr in node.instruction_addrs:
-                return node.thumb
-        if addr % 2 == 0:
-            return self.is_thumb(self.normalize_addr(addr + 1))
-        else:
-            logger.error(f"Cannot find a block containing address {hex(addr)}")
+        # Thumb instructions sit at odd addresses in angr's model, so an even
+        # address may be recorded either way; check both parities.
+        for candidate in (loaded_addr, loaded_addr | 1):
+            for node in self.cfg.model.nodes():
+                if candidate in node.instruction_addrs:
+                    return node.thumb
+
+        return self._thumb_from_mapping_symbols(loaded_addr)
+
+    def is_thumb(self, addr: int) -> bool:
+        """
+        Whether ``addr`` is Thumb, defaulting to ARM when undeterminable.
+
+        Prefer :meth:`thumb_mode` where an undeterminable address can be
+        refused: decoding Thumb bytes as ARM fuses two 16-bit instructions into
+        one, so a wrong answer here silently relocates instructions that do not
+        exist in the binary.
+        """
+        mode = self.thumb_mode(addr)
+        if mode is None:
+            logger.warning(
+                f"Cannot determine whether {hex(addr)} is ARM or Thumb: no "
+                f"mapping symbol or recovered basic block covers it. Assuming "
+                f"ARM, which will decode incorrectly if it is in fact Thumb. "
+                f"Use thumb_mode() to detect this case."
+            )
             return False
+        return mode

--- a/tests/test_is_thumb.py
+++ b/tests/test_is_thumb.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python
+
+# ruff: noqa
+import bisect
+import os
+
+import pytest
+from elftools.elf.elffile import ELFFile
+
+from patcherex2.components.binary_analyzers.angr import Angr
+
+bin_location = str(
+    os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_binaries/armhf")
+)
+
+MAPPING_KINDS = {"$t": True, "$a": False, "$d": None}
+
+
+def mode_from_elf(analyzer, loaded_addr):
+    """Instruction set at an address per the ELF mapping symbols alone."""
+    addrs, kinds = analyzer._arm_mapping_symbols
+    idx = bisect.bisect_right(addrs, loaded_addr) - 1
+    if idx < 0:
+        return None
+    return MAPPING_KINDS[kinds[idx]]
+
+
+def thumb_regions(analyzer):
+    """(start, end) of each $t region, bounded by the next mapping symbol."""
+    addrs, kinds = analyzer._arm_mapping_symbols
+    return [
+        (addr, addrs[i + 1] if i + 1 < len(addrs) else addr + 2)
+        for i, (addr, kind) in enumerate(zip(addrs, kinds))
+        if kind == "$t"
+    ]
+
+
+@pytest.fixture(scope="module")
+def nopie():
+    a = Angr(os.path.join(bin_location, "printf_nopie"))
+    a.cfg  # force recovery
+    return a
+
+
+@pytest.fixture(scope="module")
+def pie():
+    a = Angr(os.path.join(bin_location, "printf_pie"))
+    a.cfg
+    return a
+
+
+class TestThumbMode:
+    def test_cfg_uncovered_thumb_address_is_not_reported_as_arm(self, nopie):
+        """
+        The issue-38 case: addresses inside a $t region that no recovered basic
+        block covers. These used to return False ("ARM"), which decodes two
+        16-bit Thumb instructions as one 32-bit ARM instruction and relocates an
+        instruction that is not in the binary.
+        """
+        covered = set()
+        for node in nopie.cfg.model.nodes():
+            covered.update(node.instruction_addrs)
+
+        regions = thumb_regions(nopie)
+        assert regions, "test binary has no Thumb regions"
+
+        uncovered = [
+            addr
+            for start, end in regions
+            for addr in range(start, end, 2)
+            if addr not in covered and (addr | 1) not in covered
+        ]
+        assert uncovered, "no CFG-uncovered Thumb addresses to exercise"
+
+        for addr in uncovered:
+            norm = nopie.normalize_addr(addr)
+            assert nopie.is_thumb(norm) is True, hex(addr)
+            assert nopie.thumb_mode(norm) is True, hex(addr)
+
+    def test_arm_regions_still_report_arm(self, nopie):
+        for addr, kind in zip(*nopie._arm_mapping_symbols):
+            if kind != "$a":
+                continue
+            norm = nopie.normalize_addr(addr)
+            if nopie.thumb_mode(norm) is None:
+                continue
+            assert nopie.is_thumb(norm) is False, hex(addr)
+
+    def test_thumb_boundaries_report_thumb(self, nopie):
+        for addr, kind in zip(*nopie._arm_mapping_symbols):
+            if kind != "$t":
+                continue
+            assert nopie.is_thumb(nopie.normalize_addr(addr)) is True, hex(addr)
+
+    def test_data_region_is_undeterminable_not_arm(self, nopie):
+        """$d is data, so no instruction set applies: thumb_mode says so."""
+        data_addrs = [
+            addr for addr, kind in zip(*nopie._arm_mapping_symbols) if kind == "$d"
+        ]
+        assert data_addrs
+        assert any(
+            nopie.thumb_mode(nopie.normalize_addr(a)) is None for a in data_addrs
+        )
+
+    def test_is_thumb_stays_boolean(self, nopie):
+        """
+        is_thumb has ~20 call sites doing `1 if is_thumb(x) else 0`; it must never
+        return None, or they would silently take the ARM branch.
+        """
+        addrs, _ = nopie._arm_mapping_symbols
+        # Includes addresses past the last region, where nothing can resolve the
+        # mode -- is_thumb must still hand back a bool there.
+        probe = list(addrs) + [addrs[-1] + 2, addrs[-1] + 0x1000]
+        for addr in probe:
+            assert isinstance(nopie.is_thumb(nopie.normalize_addr(addr)), bool), hex(
+                addr
+            )
+
+    def test_cfg_wins_over_incomplete_mapping_symbols(self, pie):
+        """
+        Mapping symbols must not override recovered code. printf_pie has $t at
+        0x500 covering Thumb frame_dummy, but no $a marking ARM main at 0x504 --
+        the symbols alone imply Thumb for an ARM function.
+        """
+        main_norm = 0x504
+        assert mode_from_elf(pie, pie.denormalize_addr(main_norm)) is True, (
+            "precondition: mapping symbols should mislead here"
+        )
+        assert pie.thumb_mode(main_norm) is False
+        assert pie.is_thumb(main_norm) is False
+
+    def test_non_arm_arch_is_never_thumb(self):
+        amd64 = Angr(os.path.join(bin_location, "..", "amd64", "printf_nopie"))
+        assert amd64.is_thumb(0x401000) is False
+        assert amd64.thumb_mode(0x401000) is False
+
+
+def elf_thumb_regions(path):
+    """
+    $t regions read straight from the ELF with pyelftools.
+
+    Deliberately independent of the analyzer under test: a regression test that
+    sourced its ground truth from Angr._arm_mapping_symbols would still pass if
+    the lookup were reverted, since it would simply find no regions to check.
+    """
+    with open(path, "rb") as f:
+        elf = ELFFile(f)
+        marks = sorted(
+            (sym["st_value"], sym.name)
+            for section in elf.iter_sections()
+            if section.header["sh_type"] in ("SHT_SYMTAB", "SHT_DYNSYM")
+            for sym in section.iter_symbols()
+            if sym.name in ("$a", "$t", "$d")
+        )
+    return [
+        (addr, marks[i + 1][0] if i + 1 < len(marks) else addr + 2)
+        for i, (addr, kind) in enumerate(marks)
+        if kind == "$t"
+    ]
+
+
+class TestAgreementWithElf:
+    """
+    Sweep against ground truth read independently from the ELF: a Thumb address
+    the CFG does not cover must not come back as ARM.
+    """
+
+    @pytest.mark.parametrize(
+        "binary", ["printf_nopie", "printf_pie", "iip_c", "replace_function_patch"]
+    )
+    def test_no_thumb_region_reported_as_arm(self, binary):
+        path = os.path.join(bin_location, binary)
+        regions = elf_thumb_regions(path)
+        assert regions, f"{binary}: no $t regions found in the ELF"
+
+        a = Angr(path)
+        a.cfg
+        covered = set()
+        for node in a.cfg.model.nodes():
+            covered.update(node.instruction_addrs)
+
+        # ELF symbol values are unrebased; match them to the analyzer's space.
+        base = a.p.loader.main_object.mapped_base if a.p.loader.main_object.pic else 0
+
+        disagreements = []
+        checked = 0
+        for start, end in regions:
+            for addr in range(start + base, end + base, 2):
+                # Only where the CFG cannot speak: that is the fallback path.
+                if addr in covered or (addr | 1) in covered:
+                    continue
+                checked += 1
+                if a.is_thumb(a.normalize_addr(addr)) is not True:
+                    disagreements.append(hex(addr))
+
+        assert checked, f"{binary}: no CFG-uncovered Thumb addresses to check"
+        assert not disagreements, (
+            f"{binary}: {len(disagreements)}/{checked} Thumb addresses reported "
+            f"as ARM: {disagreements[:10]}"
+        )


### PR DESCRIPTION
Addresses purseclab/Patcherex2#38. To be PR'd upstream once merged here.

## Summary

`is_thumb` returned `False` — i.e. "ARM" — for any address the CFG did not cover, rather than reporting that it could not tell. On a Thumb address that answer is wrong, and because `get_instr_bytes_at` and `insert_trampoline_code` both consult it, patcherex2 would decode and **relocate instructions that do not exist in the binary**: 32-bit ARM decoding of Thumb bytes consumes two 16-bit instructions as one. `apply_patches()` raised nothing.

The bug reproduces on this repo's own ARM test binaries — no special binary needed. `0x1031a` in `printf_nopie` sits inside the `$t` region starting at `0x10318`, but no recovered block covers it, so the old code answered ARM.

## Changes

**Fall back to ELF `$a`/`$t`/`$d` mapping symbols** where the CFG has nothing to say. Those survive incomplete recovery, which is exactly the case the old constant fallback guessed at.

**The CFG is still consulted first, deliberately.** Mapping symbols are *not* reliable enough to override recovered code, because toolchains omit them. In `tests/test_binaries/armhf/printf_pie`, the `$t` at `0x500` covers Thumb `frame_dummy`, but no `$a` marks ARM `main` at `0x504` — so the symbols alone imply Thumb for a function that disassembles cleanly only as ARM:

```
bytes at 0x504: 00482de90db0a0e108d04de2
  ARM  : push {fp, lr}; mov fp, sp; sub sp, sp, #8; movw r0, #0   <- coherent
  THUMB: ldr r0, [pc, #0]                                          <- garbage
```

I had it the other way round first (symbols first, per the issue's suggested resolution 1) and it regressed four ARM PIE tests for precisely this reason.

**Add `thumb_mode()` returning `True`/`False`/`None`** for callers that can refuse an undeterminable site — the issue's resolution 2.

`is_thumb` keeps its `bool` return and becomes a thin wrapper that warns before assuming ARM. This is deliberate: its ~20 call sites all do `1 if is_thumb(x) else 0` or pass the value straight into a `thumb if flag else arm` selector. Returning `None` from `is_thumb` would be **falsy**, so every one of those sites would take the ARM branch and reintroduce the identical silent corruption — but behind an API that looked like it handled the case. Not one existing call site has a branch that could act on a third state.

## Verification

Regression test reads `$t` regions from the ELF with **pyelftools**, independently of the analyzer under test, so it cannot pass trivially if the lookup is reverted (a test sourcing ground truth from `Angr._arm_mapping_symbols` would simply find no regions and pass).

On the unfixed code it fails with a real assertion — **129 Thumb addresses across four binaries answered as ARM**:

```
printf_nopie          : 28/28  ['0x1031a', '0x1031e', '0x1032a', ...]
printf_pie            : 28/28  ['0x40040a', '0x40040e', '0x40041a', ...]
iip_c                 : 40/40  ['0x410526', '0x41052a', '0x410536', ...]
replace_function_patch: 33/33  ['0x4003fe', '0x400402', '0x40040e', ...]
```

With the fix, all 11 new tests pass and the sweep reports 0 disagreements. `get_instr_bytes_at(0x1031a)` now returns the correct 2-byte Thumb instruction instead of fused/empty bytes.

Also covered: ARM regions still report `False`; `$d` data regions report `thumb_mode() is None`; `is_thumb` never returns non-`bool`; non-ARM architectures short-circuit; and the CFG-wins-over-incomplete-symbols case above.

**Full suite: 517 passed, 67 skipped, 0 failed** (all architectures, angr and ghidra). `tests/test_arm.py` is 44 passed / 2 skipped both before and after. `ruff format --check` and `ruff check` clean.

## Not addressed

The issue also notes there is no injection point for a custom `BinaryAnalyzer`, so a caller cannot supply its own mode oracle. That is a separate API change and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)