### PR TITLE
refactor: rename analyzer backends, bind them to the Protocol, and mark overrides

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,8 @@ dependencies = [
     "lief",
     "keystone-engine",
     "intelhex",
-    "requests"
+    "requests",
+    "typing-extensions>=4.4; python_version < '3.12'"
 ]
 
 [project.optional-dependencies]

--- a/src/patcherex2/components/binary_analyzers/angr.py
+++ b/src/patcherex2/components/binary_analyzers/angr.py
@@ -3,14 +3,18 @@ from __future__ import annotations
 import bisect
 import logging
 import traceback
+from typing import final
 
 import angr
 from archinfo import ArchARM
 
+from .binary_analyzer import BinaryAnalyzer
+
 logger = logging.getLogger(__name__)
 
 
-class Angr:
+@final
+class AngrAnalyzer(BinaryAnalyzer):
     def __init__(self, binary_path: str, **kwargs) -> None:
         self.binary_path = binary_path
         # self.use_pickle = kwargs.pop("use_pickle", False) # TODO: implement this
@@ -147,7 +151,7 @@ class Angr:
 
         raise ValueError(f"Cannot find a block containing address {hex(addr)}")
 
-    def get_instr_bytes_at(self, addr: int, num_instr=1) -> angr.Block:
+    def get_instr_bytes_at(self, addr: int, num_instr: int = 1) -> bytes | None:
         addr += 1 if self.is_thumb(addr) else 0
         addr = self.denormalize_addr(addr)
         # TODO: Special handling for delay slot, when there is a call instr with delay slot

--- a/src/patcherex2/components/binary_analyzers/angr.py
+++ b/src/patcherex2/components/binary_analyzers/angr.py
@@ -2,11 +2,17 @@ from __future__ import annotations
 
 import bisect
 import logging
+import sys
 import traceback
 from typing import final
 
 import angr
 from archinfo import ArchARM
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 from .binary_analyzer import BinaryAnalyzer
 
@@ -26,16 +32,19 @@ class AngrAnalyzer(BinaryAnalyzer):
         self._mapping_symbols = None
 
     @property
+    @override
     def load_base(self) -> int:
         if self._load_base is None:
             self._load_base = self.p.loader.main_object.mapped_base
         return self._load_base
 
+    @override
     def normalize_addr(self, addr: int) -> int:
         if self.p.loader.main_object.pic:
             return addr - self.load_base
         return addr
 
+    @override
     def denormalize_addr(self, addr: int) -> int:
         if self.p.loader.main_object.pic:
             return addr + self.load_base
@@ -62,6 +71,7 @@ class AngrAnalyzer(BinaryAnalyzer):
             logger.info("Generated CFG with angr")
         return self._cfg
 
+    @override
     def mem_addr_to_file_offset(self, addr: int) -> int:
         addr = self.denormalize_addr(addr)
         file_addr = self.p.loader.main_object.addr_to_offset(addr)
@@ -72,6 +82,7 @@ class AngrAnalyzer(BinaryAnalyzer):
             return addr
         return file_addr
 
+    @override
     def get_basic_block(self, addr: int) -> dict[str, int | list[int]]:
         # NOTE: angr splits basic blocks at call instructions, so we need to handle this
         if self.is_thumb(addr) and addr % 2 == 0:
@@ -151,6 +162,7 @@ class AngrAnalyzer(BinaryAnalyzer):
 
         raise ValueError(f"Cannot find a block containing address {hex(addr)}")
 
+    @override
     def get_instr_bytes_at(self, addr: int, num_instr: int = 1) -> bytes | None:
         addr += 1 if self.is_thumb(addr) else 0
         addr = self.denormalize_addr(addr)
@@ -158,6 +170,7 @@ class AngrAnalyzer(BinaryAnalyzer):
         # angr will return both instrs, even when num_instr is 1
         return self.p.factory.block(addr, num_inst=num_instr).bytes
 
+    @override
     def get_unused_funcs(self) -> list[dict[str, int]]:
         logger.info("Getting unused functions with angr")
         unused_funcs = []
@@ -178,6 +191,7 @@ class AngrAnalyzer(BinaryAnalyzer):
                 )
         return unused_funcs
 
+    @override
     def get_all_symbols(self) -> dict[str, int]:
         assert self.cfg is not None
         logger.info("Getting all symbols with angr")
@@ -195,6 +209,7 @@ class AngrAnalyzer(BinaryAnalyzer):
             symbols[func.name] = self.normalize_addr(func.addr)
         return symbols
 
+    @override
     def get_function(self, name_or_addr: int | str) -> dict[str, int] | None:
         assert self.cfg is not None
         if isinstance(name_or_addr, (str, int)):
@@ -292,6 +307,7 @@ class AngrAnalyzer(BinaryAnalyzer):
 
         return self._thumb_from_mapping_symbols(loaded_addr)
 
+    @override
     def is_thumb(self, addr: int) -> bool:
         """
         Whether ``addr`` is Thumb, defaulting to ARM when undeterminable.

--- a/src/patcherex2/components/binary_analyzers/binary_analyzer.py
+++ b/src/patcherex2/components/binary_analyzers/binary_analyzer.py
@@ -45,8 +45,11 @@ class BinaryAnalyzer(Protocol):
         ...
 
     @abstractmethod
-    def get_instr_bytes_at(self, addr: int, num_instr: int = 1) -> bytes:
-        """Return the raw bytes of ``num_instr`` instructions starting at ``addr``."""
+    def get_instr_bytes_at(self, addr: int, num_instr: int = 1) -> bytes | None:
+        """Return the raw bytes of ``num_instr`` instructions starting at ``addr``.
+
+        ``None`` is returned when no instruction is found at ``addr``.
+        """
         ...
 
     @abstractmethod

--- a/src/patcherex2/components/binary_analyzers/ghidra.py
+++ b/src/patcherex2/components/binary_analyzers/ghidra.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
 import logging
+import sys
 import tempfile
 from typing import final
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 from .binary_analyzer import BinaryAnalyzer
 
@@ -32,6 +38,7 @@ class GhidraAnalyzer(BinaryAnalyzer):
         self.temp_proj_dir_ctx.__exit__(None, None, None)
 
     @property
+    @override
     def load_base(self) -> int:
         return self.currentProgram.getImageBase().getOffset()
 
@@ -40,17 +47,20 @@ class GhidraAnalyzer(BinaryAnalyzer):
     # declared on BinaryAnalyzer. Reconciling that would change how addresses
     # flow through this class; the annotations are left off deliberately so the
     # divergence stays visible here rather than being asserted away.
+    @override
     def normalize_addr(self, addr):  # type: ignore[override]
         addr = addr.getOffset()
         if self.currentProgram.getRelocationTable().isRelocatable():
             addr -= self.load_base
         return addr
 
+    @override
     def denormalize_addr(self, addr):  # type: ignore[override]
         if self.currentProgram.getRelocationTable().isRelocatable():
             addr += self.load_base
         return self.flatapi.toAddr(hex(addr))
 
+    @override
     def mem_addr_to_file_offset(self, addr: int) -> int:
         addr = self.denormalize_addr(addr)
         try:
@@ -62,6 +72,7 @@ class GhidraAnalyzer(BinaryAnalyzer):
         except Exception:  # noqa: BLE001
             raise ValueError("Can't get file offset for addr") from None
 
+    @override
     def get_basic_block(self, addr: int) -> dict[str, int | list[int]]:
         logger.info(f"getting basic block at 0x{addr} with ghidra")
         addr = self.denormalize_addr(addr)
@@ -82,6 +93,7 @@ class GhidraAnalyzer(BinaryAnalyzer):
             "instruction_addrs": instrs,
         }
 
+    @override
     def get_instr_bytes_at(self, addr: int, num_instr=1):
         addr = self.denormalize_addr(addr)
         instr = self.currentProgram.getListing().getInstructionContaining(addr)
@@ -96,6 +108,7 @@ class GhidraAnalyzer(BinaryAnalyzer):
         )
         return b
 
+    @override
     def get_unused_funcs(self) -> list[dict[str, int]]:
         logger.info("getting unused funcs with ghidra")
         fi = self.currentProgram.getListing().getFunctions(True)
@@ -111,6 +124,7 @@ class GhidraAnalyzer(BinaryAnalyzer):
                 )
         return unused_funcs
 
+    @override
     def get_all_symbols(self) -> dict[str, int]:
         logger.info("getting all symbols with ghidra")
         symbols = {}
@@ -129,6 +143,7 @@ class GhidraAnalyzer(BinaryAnalyzer):
                 symbols[f.getName()] += 1
         return symbols
 
+    @override
     def get_function(self, name_or_addr: int | str) -> dict[str, int] | None:
         if isinstance(name_or_addr, int):
             name_or_addr = self.denormalize_addr(name_or_addr)
@@ -149,6 +164,7 @@ class GhidraAnalyzer(BinaryAnalyzer):
             "size": b.getNumAddresses(),
         }
 
+    @override
     def is_thumb(self, addr: int) -> bool:
         addr = self.denormalize_addr(addr)
         r = self.currentProgram.getRegister("TMode")

--- a/src/patcherex2/components/binary_analyzers/ghidra.py
+++ b/src/patcherex2/components/binary_analyzers/ghidra.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import logging
 import tempfile
+from typing import final
+
+from .binary_analyzer import BinaryAnalyzer
 
 logger = logging.getLogger(__name__)
 
 
-class Ghidra:
+@final
+class GhidraAnalyzer(BinaryAnalyzer):
     def __init__(self, binary_path: str, **kwargs):
         import pyhidra
 
@@ -31,13 +35,18 @@ class Ghidra:
     def load_base(self) -> int:
         return self.currentProgram.getImageBase().getOffset()
 
-    def normalize_addr(self, addr):
+    # NOTE: Unlike the other backends, these two exchange Ghidra ``Address``
+    # objects rather than plain ints, so they do not match the signatures
+    # declared on BinaryAnalyzer. Reconciling that would change how addresses
+    # flow through this class; the annotations are left off deliberately so the
+    # divergence stays visible here rather than being asserted away.
+    def normalize_addr(self, addr):  # type: ignore[override]
         addr = addr.getOffset()
         if self.currentProgram.getRelocationTable().isRelocatable():
             addr -= self.load_base
         return addr
 
-    def denormalize_addr(self, addr):
+    def denormalize_addr(self, addr):  # type: ignore[override]
         if self.currentProgram.getRelocationTable().isRelocatable():
             addr += self.load_base
         return self.flatapi.toAddr(hex(addr))

--- a/src/patcherex2/components/binary_analyzers/ida.py
+++ b/src/patcherex2/components/binary_analyzers/ida.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 import logging
 import os
+import sys
 from typing import final
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
 
 from .binary_analyzer import BinaryAnalyzer
 
@@ -55,21 +61,25 @@ class IDAAnalyzer(BinaryAnalyzer):
             setattr(self, lib, self._headlessida.import_module(lib))
 
     @property
+    @override
     def load_base(self) -> int:
         if self._load_base is None:
             self._load_base = self.ida_nalt.get_imagebase()
         return self._load_base
 
+    @override
     def normalize_addr(self, addr: int) -> int:
         if self.ida_ida.inf_is_dll():
             return addr - self.load_base
         return addr
 
+    @override
     def denormalize_addr(self, addr: int) -> int:
         if self.ida_ida.inf_is_dll():
             return addr + self.load_base
         return addr
 
+    @override
     def mem_addr_to_file_offset(self, addr: int) -> int:
         file_type = self.ida_loader.get_file_type_name()
         if "intel hex" in file_type.lower():
@@ -77,6 +87,7 @@ class IDAAnalyzer(BinaryAnalyzer):
         file_offset = self.ida_loader.get_fileregion_offset(addr)
         return file_offset if file_offset != -1 else None
 
+    @override
     def get_basic_block(self, addr: int) -> dict[str, int | list[int]]:
         func = self.ida_funcs.get_func(addr)
         instr_addrs = list(func.code_items())
@@ -94,6 +105,7 @@ class IDAAnalyzer(BinaryAnalyzer):
                     ],
                 }
 
+    @override
     def get_instr_bytes_at(self, addr: int, num_instr: int = 1):
         total_bytes = b""
         current_addr = addr
@@ -103,6 +115,7 @@ class IDAAnalyzer(BinaryAnalyzer):
             current_addr += instr_len
         return total_bytes
 
+    @override
     def get_unused_funcs(self) -> list[dict[str, int]]:
         logger.info("Getting unused functions with IDA")
         unused_funcs = []
@@ -121,6 +134,7 @@ class IDAAnalyzer(BinaryAnalyzer):
                 )
         return unused_funcs
 
+    @override
     def get_all_symbols(self) -> dict[str, int]:
         logger.info("Getting all symbols with IDA")
         symbols = {}
@@ -136,6 +150,7 @@ class IDAAnalyzer(BinaryAnalyzer):
             symbols[name] = self.normalize_addr(addr)
         return symbols
 
+    @override
     def get_function(self, name_or_addr: int | str) -> dict[str, int] | None:
         if isinstance(name_or_addr, str):
             addr = self.ida_name.get_name_ea(self.ida_idaapi.BADADDR, name_or_addr)
@@ -151,5 +166,6 @@ class IDAAnalyzer(BinaryAnalyzer):
             "size": func.end_ea - func.start_ea,
         }
 
+    @override
     def is_thumb(self, addr: int) -> bool:
         return self.ida_segregs.get_sreg(addr, self.ida_idp.str2reg("T")) == 1

--- a/src/patcherex2/components/binary_analyzers/ida.py
+++ b/src/patcherex2/components/binary_analyzers/ida.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import final
+
+from .binary_analyzer import BinaryAnalyzer
 
 logger = logging.getLogger(__name__)
 
 
-class Ida:
+@final
+class IDAAnalyzer(BinaryAnalyzer):
     _DEFAULT_LOAD_BASE = 0x0
 
     def __init__(self, binary_path: str, **kwargs) -> None:

--- a/src/patcherex2/targets/bin_arm_bare.py
+++ b/src/patcherex2/targets/bin_arm_bare.py
@@ -3,7 +3,7 @@ import logging
 from ..components.allocation_managers.allocation_manager import AllocationManager
 from ..components.archinfo.arm import ArmInfo
 from ..components.assemblers.keystone_arm import KeystoneArm
-from ..components.binary_analyzers.angr import Angr
+from ..components.binary_analyzers.angr import AngrAnalyzer
 from ..components.binfmt_tools.binary import Binary
 from ..components.compilers.clang_arm import ClangArm
 from ..components.disassemblers.capstone_arm import CapstoneArm
@@ -63,7 +63,7 @@ class BinArmBare(Target):
     def get_binary_analyzer(self, binary_analyzer):
         binary_analyzer = binary_analyzer or "angr"
         if binary_analyzer == "angr":
-            return Angr(
+            return AngrAnalyzer(
                 self.binary_path,
                 angr_kwargs={
                     "arch": "ARMEL",

--- a/src/patcherex2/targets/bin_ppc_pegasos2_bare.py
+++ b/src/patcherex2/targets/bin_ppc_pegasos2_bare.py
@@ -18,7 +18,7 @@ from ..components.allocation_managers.allocation_manager import (
 )
 from ..components.archinfo.ppc import PpcInfo
 from ..components.assemblers.keystone import Keystone, keystone
-from ..components.binary_analyzers.angr import Angr
+from ..components.binary_analyzers.angr import AngrAnalyzer
 from ..components.binfmt_tools.binary import Binary
 from ..components.compilers.clang import Clang
 from ..components.disassemblers.capstone import Capstone, capstone
@@ -176,7 +176,7 @@ class BinPpcPegasos2Bare(Target):
         entry_point = kwargs.pop("entry_point", _DEFAULT_ENTRY)
         binary_analyzer = binary_analyzer or "angr"
         if binary_analyzer == "angr":
-            return Angr(
+            return AngrAnalyzer(
                 self.binary_path,
                 angr_kwargs={
                     "main_opts": {

--- a/src/patcherex2/targets/elf_aarch64_linux.py
+++ b/src/patcherex2/targets/elf_aarch64_linux.py
@@ -3,8 +3,8 @@ import logging
 from ..components.allocation_managers.allocation_manager import AllocationManager
 from ..components.archinfo.aarch64 import Aarch64Info
 from ..components.assemblers.keystone import Keystone, keystone
-from ..components.binary_analyzers.angr import Angr
-from ..components.binary_analyzers.ghidra import Ghidra
+from ..components.binary_analyzers.angr import AngrAnalyzer
+from ..components.binary_analyzers.ghidra import GhidraAnalyzer
 from ..components.binfmt_tools.elf import ELF
 from ..components.compilers.clang import Clang
 from ..components.disassemblers.capstone import Capstone, capstone
@@ -72,9 +72,9 @@ class ElfAArch64Linux(Target):
     def get_binary_analyzer(self, binary_analyzer, **kwargs):
         binary_analyzer = binary_analyzer or "angr"
         if binary_analyzer == "angr":
-            return Angr(self.binary_path, **kwargs)
+            return AngrAnalyzer(self.binary_path, **kwargs)
         if binary_analyzer == "ghidra":
-            return Ghidra(self.binary_path, **kwargs)
+            return GhidraAnalyzer(self.binary_path, **kwargs)
         raise NotImplementedError()
 
     def get_utils(self, utils):

--- a/src/patcherex2/targets/elf_amd64_linux.py
+++ b/src/patcherex2/targets/elf_amd64_linux.py
@@ -1,9 +1,9 @@
 from ..components.allocation_managers.allocation_manager import AllocationManager
 from ..components.archinfo.amd64 import Amd64Info
 from ..components.assemblers.keystone import Keystone, keystone
-from ..components.binary_analyzers.angr import Angr
-from ..components.binary_analyzers.ghidra import Ghidra
-from ..components.binary_analyzers.ida import Ida
+from ..components.binary_analyzers.angr import AngrAnalyzer
+from ..components.binary_analyzers.ghidra import GhidraAnalyzer
+from ..components.binary_analyzers.ida import IDAAnalyzer
 from ..components.binfmt_tools.elf import ELF
 from ..components.compilers.clang import Clang
 from ..components.disassemblers.capstone import Capstone, capstone
@@ -74,11 +74,11 @@ class ElfAmd64Linux(Target):
     def get_binary_analyzer(self, binary_analyzer, **kwargs):
         binary_analyzer = binary_analyzer or "angr"
         if binary_analyzer == "angr":
-            return Angr(self.binary_path, **kwargs)
+            return AngrAnalyzer(self.binary_path, **kwargs)
         if binary_analyzer == "ghidra":
-            return Ghidra(self.binary_path, **kwargs)
+            return GhidraAnalyzer(self.binary_path, **kwargs)
         if binary_analyzer == "ida":
-            return Ida(self.binary_path, **kwargs)
+            return IDAAnalyzer(self.binary_path, **kwargs)
         raise NotImplementedError()
 
     def get_utils(self, utils):

--- a/src/patcherex2/targets/elf_amd64_linux_recomp.py
+++ b/src/patcherex2/targets/elf_amd64_linux_recomp.py
@@ -1,6 +1,6 @@
-from ..components.binary_analyzers.angr import Angr
-from ..components.binary_analyzers.ghidra import Ghidra
-from ..components.binary_analyzers.ida import Ida
+from ..components.binary_analyzers.angr import AngrAnalyzer
+from ..components.binary_analyzers.ghidra import GhidraAnalyzer
+from ..components.binary_analyzers.ida import IDAAnalyzer
 from ..components.compilers.llvm_recomp import LLVMRecomp
 from .elf_amd64_linux import ElfAmd64Linux
 
@@ -19,9 +19,9 @@ class ElfAmd64LinuxRecomp(ElfAmd64Linux):
     def get_binary_analyzer(self, binary_analyzer, **kwargs):
         binary_analyzer = binary_analyzer or "angr"
         if binary_analyzer == "angr":
-            return Angr(self.binary_path, **kwargs)
+            return AngrAnalyzer(self.binary_path, **kwargs)
         if binary_analyzer == "ghidra":
-            return Ghidra(self.binary_path, **kwargs)
+            return GhidraAnalyzer(self.binary_path, **kwargs)
         if binary_analyzer == "ida":
-            return Ida(self.binary_path, **kwargs)
+            return IDAAnalyzer(self.binary_path, **kwargs)
         raise NotImplementedError()

--- a/src/patcherex2/targets/elf_arm_linux.py
+++ b/src/patcherex2/targets/elf_arm_linux.py
@@ -1,8 +1,8 @@
 from ..components.allocation_managers.allocation_manager import AllocationManager
 from ..components.archinfo.arm import ArmInfo
 from ..components.assemblers.keystone_arm import KeystoneArm
-from ..components.binary_analyzers.angr import Angr
-from ..components.binary_analyzers.ghidra import Ghidra
+from ..components.binary_analyzers.angr import AngrAnalyzer
+from ..components.binary_analyzers.ghidra import GhidraAnalyzer
 from ..components.binfmt_tools.elf import ELF
 from ..components.compilers.clang_arm import ClangArm
 from ..components.disassemblers.capstone_arm import CapstoneArm
@@ -66,9 +66,9 @@ class ElfArmLinux(Target):
     def get_binary_analyzer(self, binary_analyzer, **kwargs):
         binary_analyzer = binary_analyzer or "angr"
         if binary_analyzer == "angr":
-            return Angr(self.binary_path, **kwargs)
+            return AngrAnalyzer(self.binary_path, **kwargs)
         if binary_analyzer == "ghidra":
-            return Ghidra(self.binary_path, **kwargs)
+            return GhidraAnalyzer(self.binary_path, **kwargs)
         raise NotImplementedError()
 
     def get_utils(self, utils):

--- a/src/patcherex2/targets/elf_arm_linux_recomp.py
+++ b/src/patcherex2/targets/elf_arm_linux_recomp.py
@@ -1,5 +1,5 @@
-from ..components.binary_analyzers.angr import Angr
-from ..components.binary_analyzers.ghidra import Ghidra
+from ..components.binary_analyzers.angr import AngrAnalyzer
+from ..components.binary_analyzers.ghidra import GhidraAnalyzer
 from ..components.compilers.llvm_recomp_arm import LLVMRecompArm
 from .elf_arm_linux import ElfArmLinux
 
@@ -20,7 +20,7 @@ class ElfArmLinuxRecomp(ElfArmLinux):
     def get_binary_analyzer(self, binary_analyzer, **kwargs):
         binary_analyzer = binary_analyzer or "angr"
         if binary_analyzer == "angr":
-            return Angr(self.binary_path, **kwargs)
+            return AngrAnalyzer(self.binary_path, **kwargs)
         if binary_analyzer == "ghidra":
-            return Ghidra(self.binary_path, **kwargs)
+            return GhidraAnalyzer(self.binary_path, **kwargs)
         raise NotImplementedError()

--- a/src/patcherex2/targets/elf_leon3_bare.py
+++ b/src/patcherex2/targets/elf_leon3_bare.py
@@ -8,8 +8,8 @@ from ..components.allocation_managers.allocation_manager import (
 from ..components.archinfo.sparc import SparcInfo
 from ..components.assemblers.bcc import Bcc as BccAssembler
 from ..components.assemblers.keystone_sparc import KeystoneSparc, keystone
-from ..components.binary_analyzers.angr import Angr
-from ..components.binary_analyzers.ghidra import Ghidra
+from ..components.binary_analyzers.angr import AngrAnalyzer
+from ..components.binary_analyzers.ghidra import GhidraAnalyzer
 from ..components.binfmt_tools.elf import ELF
 from ..components.compilers.bcc import Bcc as BccCompiler
 from ..components.disassemblers.capstone import Capstone, capstone
@@ -83,9 +83,9 @@ class ElfLeon3Bare(Target):
     def get_binary_analyzer(self, binary_analyzer, **kwargs):
         binary_analyzer = binary_analyzer or "angr"
         if binary_analyzer == "angr":
-            return Angr(self.binary_path, **kwargs)
+            return AngrAnalyzer(self.binary_path, **kwargs)
         if binary_analyzer == "ghidra":
-            return Ghidra(self.binary_path, **kwargs)
+            return GhidraAnalyzer(self.binary_path, **kwargs)
         raise NotImplementedError()
 
     def get_utils(self, utils):

--- a/src/patcherex2/targets/elf_mips64_linux.py
+++ b/src/patcherex2/targets/elf_mips64_linux.py
@@ -1,8 +1,8 @@
 from ..components.allocation_managers.allocation_manager import AllocationManager
 from ..components.archinfo.mips64 import Mips64Info
 from ..components.assemblers.keystone import Keystone, keystone
-from ..components.binary_analyzers.angr import Angr
-from ..components.binary_analyzers.ghidra import Ghidra
+from ..components.binary_analyzers.angr import AngrAnalyzer
+from ..components.binary_analyzers.ghidra import GhidraAnalyzer
 from ..components.binfmt_tools.elf import ELF
 from ..components.compilers.clang import Clang
 from ..components.disassemblers.capstone import Capstone, capstone
@@ -67,9 +67,9 @@ class ElfMips64Linux(Target):
     def get_binary_analyzer(self, binary_analyzer, **kwargs):
         binary_analyzer = binary_analyzer or "angr"
         if binary_analyzer == "angr":
-            return Angr(self.binary_path, **kwargs)
+            return AngrAnalyzer(self.binary_path, **kwargs)
         if binary_analyzer == "ghidra":
-            return Ghidra(self.binary_path, **kwargs)
+            return GhidraAnalyzer(self.binary_path, **kwargs)
         raise NotImplementedError()
 
     def get_utils(self, utils):

--- a/src/patcherex2/targets/elf_mips64el_linux.py
+++ b/src/patcherex2/targets/elf_mips64el_linux.py
@@ -1,8 +1,8 @@
 from ..components.allocation_managers.allocation_manager import AllocationManager
 from ..components.archinfo.mips64 import Mips64Info
 from ..components.assemblers.keystone import Keystone, keystone
-from ..components.binary_analyzers.angr import Angr
-from ..components.binary_analyzers.ghidra import Ghidra
+from ..components.binary_analyzers.angr import AngrAnalyzer
+from ..components.binary_analyzers.ghidra import GhidraAnalyzer
 from ..components.binfmt_tools.elf import ELF
 from ..components.compilers.clang import Clang
 from ..components.disassemblers.capstone import Capstone, capstone
@@ -67,9 +67,9 @@ class ElfMips64elLinux(Target):
     def get_binary_analyzer(self, binary_analyzer, **kwargs):
         binary_analyzer = binary_analyzer or "angr"
         if binary_analyzer == "angr":
-            return Angr(self.binary_path, **kwargs)
+            return AngrAnalyzer(self.binary_path, **kwargs)
         if binary_analyzer == "ghidra":
-            return Ghidra(self.binary_path, **kwargs)
+            return GhidraAnalyzer(self.binary_path, **kwargs)
         raise NotImplementedError()
 
     def get_utils(self, utils):

--- a/src/patcherex2/targets/elf_mips_linux.py
+++ b/src/patcherex2/targets/elf_mips_linux.py
@@ -1,8 +1,8 @@
 from ..components.allocation_managers.allocation_manager import AllocationManager
 from ..components.archinfo.mips import MipsInfo
 from ..components.assemblers.keystone import Keystone, keystone
-from ..components.binary_analyzers.angr import Angr
-from ..components.binary_analyzers.ghidra import Ghidra
+from ..components.binary_analyzers.angr import AngrAnalyzer
+from ..components.binary_analyzers.ghidra import GhidraAnalyzer
 from ..components.binfmt_tools.elf import ELF
 from ..components.compilers.clang import Clang
 from ..components.disassemblers.capstone import Capstone, capstone
@@ -67,9 +67,9 @@ class ElfMipsLinux(Target):
     def get_binary_analyzer(self, binary_analyzer, **kwargs):
         binary_analyzer = binary_analyzer or "angr"
         if binary_analyzer == "angr":
-            return Angr(self.binary_path, **kwargs)
+            return AngrAnalyzer(self.binary_path, **kwargs)
         if binary_analyzer == "ghidra":
-            return Ghidra(self.binary_path, **kwargs)
+            return GhidraAnalyzer(self.binary_path, **kwargs)
         raise NotImplementedError()
 
     def get_utils(self, utils):

--- a/src/patcherex2/targets/elf_mipsel_linux.py
+++ b/src/patcherex2/targets/elf_mipsel_linux.py
@@ -1,8 +1,8 @@
 from ..components.allocation_managers.allocation_manager import AllocationManager
 from ..components.archinfo.mips import MipsInfo
 from ..components.assemblers.keystone import Keystone, keystone
-from ..components.binary_analyzers.angr import Angr
-from ..components.binary_analyzers.ghidra import Ghidra
+from ..components.binary_analyzers.angr import AngrAnalyzer
+from ..components.binary_analyzers.ghidra import GhidraAnalyzer
 from ..components.binfmt_tools.elf import ELF
 from ..components.compilers.clang import Clang
 from ..components.disassemblers.capstone import Capstone, capstone
@@ -67,9 +67,9 @@ class ElfMipselLinux(Target):
     def get_binary_analyzer(self, binary_analyzer, **kwargs):
         binary_analyzer = binary_analyzer or "angr"
         if binary_analyzer == "angr":
-            return Angr(self.binary_path, **kwargs)
+            return AngrAnalyzer(self.binary_path, **kwargs)
         if binary_analyzer == "ghidra":
-            return Ghidra(self.binary_path, **kwargs)
+            return GhidraAnalyzer(self.binary_path, **kwargs)
         raise NotImplementedError()
 
     def get_utils(self, utils):

--- a/src/patcherex2/targets/elf_ppc64_linux.py
+++ b/src/patcherex2/targets/elf_ppc64_linux.py
@@ -1,8 +1,8 @@
 from ..components.allocation_managers.allocation_manager import AllocationManager
 from ..components.archinfo.ppc64 import Ppc64Info
 from ..components.assemblers.keystone import Keystone, keystone
-from ..components.binary_analyzers.angr import Angr
-from ..components.binary_analyzers.ghidra import Ghidra
+from ..components.binary_analyzers.angr import AngrAnalyzer
+from ..components.binary_analyzers.ghidra import GhidraAnalyzer
 from ..components.binfmt_tools.elf import ELF
 from ..components.compilers.clang import Clang
 from ..components.disassemblers.capstone import Capstone, capstone
@@ -69,9 +69,9 @@ class ElfPpc64Linux(Target):
     def get_binary_analyzer(self, binary_analyzer, **kwargs):
         binary_analyzer = binary_analyzer or "angr"
         if binary_analyzer == "angr":
-            return Angr(self.binary_path, **kwargs)
+            return AngrAnalyzer(self.binary_path, **kwargs)
         if binary_analyzer == "ghidra":
-            return Ghidra(self.binary_path, **kwargs)
+            return GhidraAnalyzer(self.binary_path, **kwargs)
         raise NotImplementedError()
 
     def get_utils(self, utils):

--- a/src/patcherex2/targets/elf_ppc64le_linux.py
+++ b/src/patcherex2/targets/elf_ppc64le_linux.py
@@ -1,8 +1,8 @@
 from ..components.allocation_managers.allocation_manager import AllocationManager
 from ..components.archinfo.ppc64 import Ppc64Info
 from ..components.assemblers.keystone import Keystone, keystone
-from ..components.binary_analyzers.angr import Angr
-from ..components.binary_analyzers.ghidra import Ghidra
+from ..components.binary_analyzers.angr import AngrAnalyzer
+from ..components.binary_analyzers.ghidra import GhidraAnalyzer
 from ..components.binfmt_tools.elf import ELF
 from ..components.compilers.clang import Clang
 from ..components.disassemblers.capstone import Capstone, capstone
@@ -70,9 +70,9 @@ class ElfPpc64leLinux(Target):
     def get_binary_analyzer(self, binary_analyzer, **kwargs):
         binary_analyzer = binary_analyzer or "angr"
         if binary_analyzer == "angr":
-            return Angr(self.binary_path, **kwargs)
+            return AngrAnalyzer(self.binary_path, **kwargs)
         if binary_analyzer == "ghidra":
-            return Ghidra(self.binary_path, **kwargs)
+            return GhidraAnalyzer(self.binary_path, **kwargs)
         raise NotImplementedError()
 
     def get_utils(self, utils):

--- a/src/patcherex2/targets/elf_ppc_linux.py
+++ b/src/patcherex2/targets/elf_ppc_linux.py
@@ -1,8 +1,8 @@
 from ..components.allocation_managers.allocation_manager import AllocationManager
 from ..components.archinfo.ppc import PpcInfo
 from ..components.assemblers.keystone import Keystone, keystone
-from ..components.binary_analyzers.angr import Angr
-from ..components.binary_analyzers.ghidra import Ghidra
+from ..components.binary_analyzers.angr import AngrAnalyzer
+from ..components.binary_analyzers.ghidra import GhidraAnalyzer
 from ..components.binfmt_tools.elf import ELF
 from ..components.compilers.clang import Clang
 from ..components.disassemblers.capstone import Capstone, capstone
@@ -69,9 +69,9 @@ class ElfPpcLinux(Target):
     def get_binary_analyzer(self, binary_analyzer, **kwargs):
         binary_analyzer = binary_analyzer or "angr"
         if binary_analyzer == "angr":
-            return Angr(self.binary_path, **kwargs)
+            return AngrAnalyzer(self.binary_path, **kwargs)
         if binary_analyzer == "ghidra":
-            return Ghidra(self.binary_path, **kwargs)
+            return GhidraAnalyzer(self.binary_path, **kwargs)
         raise NotImplementedError()
 
     def get_utils(self, utils):

--- a/src/patcherex2/targets/elf_s390x_linux.py
+++ b/src/patcherex2/targets/elf_s390x_linux.py
@@ -3,8 +3,8 @@ import re
 from ..components.allocation_managers.allocation_manager import AllocationManager
 from ..components.archinfo.s390x import S390xInfo
 from ..components.assemblers.keystone import Keystone, keystone
-from ..components.binary_analyzers.angr import Angr
-from ..components.binary_analyzers.ghidra import Ghidra
+from ..components.binary_analyzers.angr import AngrAnalyzer
+from ..components.binary_analyzers.ghidra import GhidraAnalyzer
 from ..components.binfmt_tools.elf import ELF
 from ..components.compilers.clang import Clang
 from ..components.disassemblers.capstone import Capstone, capstone
@@ -82,9 +82,9 @@ class ElfS390xLinux(Target):
     def get_binary_analyzer(self, binary_analyzer, **kwargs):
         binary_analyzer = binary_analyzer or "angr"
         if binary_analyzer == "angr":
-            return Angr(self.binary_path, **kwargs)
+            return AngrAnalyzer(self.binary_path, **kwargs)
         if binary_analyzer == "ghidra":
-            return Ghidra(self.binary_path, **kwargs)
+            return GhidraAnalyzer(self.binary_path, **kwargs)
         raise NotImplementedError()
 
     def get_utils(self, utils):

--- a/src/patcherex2/targets/elf_x86_linux.py
+++ b/src/patcherex2/targets/elf_x86_linux.py
@@ -1,8 +1,8 @@
 from ..components.allocation_managers.allocation_manager import AllocationManager
 from ..components.archinfo.x86 import X86Info
 from ..components.assemblers.keystone import Keystone, keystone
-from ..components.binary_analyzers.angr import Angr
-from ..components.binary_analyzers.ghidra import Ghidra
+from ..components.binary_analyzers.angr import AngrAnalyzer
+from ..components.binary_analyzers.ghidra import GhidraAnalyzer
 from ..components.binfmt_tools.elf import ELF
 from ..components.compilers.clang import Clang
 from ..components.disassemblers.capstone import Capstone, capstone
@@ -67,9 +67,9 @@ class ElfX86Linux(Target):
     def get_binary_analyzer(self, binary_analyzer, **kwargs):
         binary_analyzer = binary_analyzer or "angr"
         if binary_analyzer == "angr":
-            return Angr(self.binary_path, **kwargs)
+            return AngrAnalyzer(self.binary_path, **kwargs)
         if binary_analyzer == "ghidra":
-            return Ghidra(self.binary_path, **kwargs)
+            return GhidraAnalyzer(self.binary_path, **kwargs)
         raise NotImplementedError()
 
     def get_utils(self, utils):

--- a/src/patcherex2/targets/ihex_ppc_bare.py
+++ b/src/patcherex2/targets/ihex_ppc_bare.py
@@ -5,7 +5,7 @@ import archinfo
 from ..components.allocation_managers.allocation_manager import AllocationManager
 from ..components.archinfo.ppc_vle import PpcVleInfo
 from ..components.assemblers.ppc_vle import PpcVle as PpcVleAssembler
-from ..components.binary_analyzers.angr import Angr
+from ..components.binary_analyzers.angr import AngrAnalyzer
 from ..components.binfmt_tools.ihex import IHex
 from ..components.compilers.ppc_vle import PpcVle as PpcVleCompiler
 from ..components.disassemblers.ppc_vle import PpcVle as PpcVleDisassembler
@@ -59,7 +59,7 @@ class IHexPPCBare(Target):
     def get_binary_analyzer(self, binary_analyzer):
         binary_analyzer = binary_analyzer or "angr"
         if binary_analyzer == "angr":
-            return Angr(
+            return AngrAnalyzer(
                 self.binary_path,
                 angr_kwargs={
                     "arch": archinfo.ArchPcode("PowerPC:BE:32:MPC8270"),

--- a/src/patcherex2/targets/ihex_riscv32_bare.py
+++ b/src/patcherex2/targets/ihex_riscv32_bare.py
@@ -4,8 +4,8 @@ from ..components.allocation_managers.allocation_manager import AllocationManage
 from ..components.archinfo.riscv32 import Riscv32Info
 from ..components.assemblers.keystone import Keystone, keystone
 from ..components.assemblers.nyxstone import Nyxstone as NyxstoneAssembler
-from ..components.binary_analyzers.angr import Angr
-from ..components.binary_analyzers.ida import Ida
+from ..components.binary_analyzers.angr import AngrAnalyzer
+from ..components.binary_analyzers.ida import IDAAnalyzer
 from ..components.binfmt_tools.ihex import IHex
 from ..components.compilers.clang import Clang
 from ..components.disassemblers.capstone import Capstone, capstone
@@ -71,7 +71,7 @@ class IHexRiscv32Bare(Target):
     def get_binary_analyzer(self, binary_analyzer):
         binary_analyzer = binary_analyzer or "ida"
         if binary_analyzer == "angr":
-            return Angr(
+            return AngrAnalyzer(
                 self.binary_path,
                 angr_kwargs={
                     "arch": "riscv32",  # 32b unsupported?
@@ -83,7 +83,7 @@ class IHexRiscv32Bare(Target):
                 },
             )
         if binary_analyzer == "ida":
-            return Ida(self.binary_path, processor="riscv")
+            return IDAAnalyzer(self.binary_path, processor="riscv")
         raise NotImplementedError()
 
     def get_utils(self, utils):

--- a/tests/test_is_thumb.py
+++ b/tests/test_is_thumb.py
@@ -7,7 +7,7 @@ import os
 import pytest
 from elftools.elf.elffile import ELFFile
 
-from patcherex2.components.binary_analyzers.angr import Angr
+from patcherex2.components.binary_analyzers.angr import AngrAnalyzer
 
 bin_location = str(
     os.path.join(os.path.dirname(os.path.realpath(__file__)), "./test_binaries/armhf")
@@ -37,14 +37,14 @@ def thumb_regions(analyzer):
 
 @pytest.fixture(scope="module")
 def nopie():
-    a = Angr(os.path.join(bin_location, "printf_nopie"))
+    a = AngrAnalyzer(os.path.join(bin_location, "printf_nopie"))
     a.cfg  # force recovery
     return a
 
 
 @pytest.fixture(scope="module")
 def pie():
-    a = Angr(os.path.join(bin_location, "printf_pie"))
+    a = AngrAnalyzer(os.path.join(bin_location, "printf_pie"))
     a.cfg
     return a
 
@@ -130,7 +130,7 @@ class TestThumbMode:
         assert pie.is_thumb(main_norm) is False
 
     def test_non_arm_arch_is_never_thumb(self):
-        amd64 = Angr(os.path.join(bin_location, "..", "amd64", "printf_nopie"))
+        amd64 = AngrAnalyzer(os.path.join(bin_location, "..", "amd64", "printf_nopie"))
         assert amd64.is_thumb(0x401000) is False
         assert amd64.thumb_mode(0x401000) is False
 
@@ -140,7 +140,7 @@ def elf_thumb_regions(path):
     $t regions read straight from the ELF with pyelftools.
 
     Deliberately independent of the analyzer under test: a regression test that
-    sourced its ground truth from Angr._arm_mapping_symbols would still pass if
+    sourced its ground truth from AngrAnalyzer._arm_mapping_symbols would still pass if
     the lookup were reverted, since it would simply find no regions to check.
     """
     with open(path, "rb") as f:
@@ -173,7 +173,7 @@ class TestAgreementWithElf:
         regions = elf_thumb_regions(path)
         assert regions, f"{binary}: no $t regions found in the ELF"
 
-        a = Angr(path)
+        a = AngrAnalyzer(path)
         a.cfg
         covered = set()
         for node in a.cfg.model.nodes():


### PR DESCRIPTION
Follow-on to the `BinaryAnalyzer` Protocol work, in two commits.

### Rename the backends and bind them to the Protocol

`Angr`, `Ghidra` and `Ida` become `AngrAnalyzer`, `GhidraAnalyzer` and
`IDAAnalyzer`, so the class names say what they are rather than colliding with
the libraries they wrap — `Angr` vs the `angr` module was especially easy to
misread. Updated across 20 files (all `targets/*.py` plus `tests/test_is_thumb.py`).

Each is now marked `@final` and inherits `BinaryAnalyzer` explicitly. Previously
the Protocol was satisfied structurally only; inheriting it means the
`@abstractmethod` declarations are enforced at construction time, so a backend
that drops a method fails loudly instead of at the call site.

### Mark the implementations with `@override`

All ten protocol methods on each backend are decorated, so a renamed or
misspelled method is reported at the definition rather than silently becoming a
new method that shadows nothing.

`typing.override` is 3.12+ and this package supports `>=3.10`, so it is imported
from `typing_extensions` below 3.12. That package was already present
transitively via angr; this declares it explicitly rather than relying on a
dependency's dependency.

### Two annotation bugs this surfaced

- `AngrAnalyzer.get_instr_bytes_at` was annotated `-> angr.Block` but returns
  `.bytes`. Corrected to `bytes | None`, and the Protocol widened to match since
  `GhidraAnalyzer` also returns `None` when no instruction is found.
- `GhidraAnalyzer.normalize_addr` / `denormalize_addr` exchange Ghidra `Address`
  objects rather than `int`, so they genuinely diverge from the declared
  signatures. Marked `type: ignore[override]` with a comment rather than changing
  how addresses flow through that class — **this divergence is documented, not
  fixed**, and is the one thing here worth a reviewer's opinion.

### Notes for review

- On `load_base` the `@override` goes *under* `@property`, not above it. It has
  to decorate the underlying function; stacking it on the property object leaves
  `__override__` set where no type checker looks. Verified at runtime that all
  three classes report 10/10 methods marked, `load_base` included.
- Checked that `@override` is not inert: renaming `is_thumb` to `is_thumbb`
  produces `error[invalid-explicit-override]`. Likewise `@final` — subclassing
  `AngrAnalyzer` produces `subclass-of-final-class`.
- No new type-checker diagnostics: `binary_analyzers/` at 31 and `targets/` at
  21, identical before and after. Those are pre-existing, from IDA's
  `setattr`-based attributes and the uninstalled optional `headless_ida`.
- `ruff check` and `ruff format --check` pass.
- **The test suite was not run.** This environment cannot `import patcherex2`
  due to a pre-existing, unrelated keystone native-library failure
  (`ImportError: fail to load the dynamic library`). CI coverage is needed here,
  particularly for the rename touching every target module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
